### PR TITLE
Glib264 migration

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -33,7 +33,7 @@ gdk_pixbuf:
 giflib:
 - '5.2'
 glib:
-- '2.58'
+- 2.64.6
 hdf5:
 - 1.10.6
 jpeg:

--- a/.ci_support/migrations/glib2646.yaml
+++ b/.ci_support/migrations/glib2646.yaml
@@ -1,0 +1,15 @@
+migrator_ts: 1
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+glib:
+  - 2.64.6  # [not (osx and arm64)]
+  - 2.66    # [osx and arm64]
+libglib:
+  - 2.64.6  # [not (osx and arm64)]
+  - 2.66    # [osx and arm64]

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -31,7 +31,7 @@ gdk_pixbuf:
 giflib:
 - '5.2'
 glib:
-- '2.58'
+- 2.64.6
 hdf5:
 - 1.10.6
 jpeg:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: 1adf3f7b73cab2ad8606e9d6cfd0768551ef7c1ff989688a83e5c8b101a94ad9
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     # SO name changes at minor rev bumps.


### PR DESCRIPTION
should be merged AFTER https://github.com/conda-forge/libvips-feedstock/pull/20 is merged

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
