### PR TITLE
Build with `-Dauto_features=enabled`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,8 +2,17 @@
 set -ex
 
 meson_config_args=(
-    -Dintrospection=enabled
-    -Dopenslide=enabled
+    -Dauto_features=enabled
+    -Dcgif=disabled
+    -Dimagequant=disabled
+    -Djpeg-xl=disabled
+    -Dmatio=disabled
+    -Dnifti=disabled
+    -Dopenexr=disabled
+    -Dpdfium=disabled
+    -Dquantizr=disabled
+    # https://github.com/conda-forge/libvips-feedstock/issues/25
+    -Dspng=disabled
 )
 
 if [ "${CONDA_BUILD_CROSS_COMPILATION}" = "1" ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 6eca46c6ba5fac86224fd69007741012b0ea1f9aa1fcb9256b0cbc2faf768563
 
 build:
-  number: 6
+  number: 7
   skip: true  # [win]
   run_exports:
     # Seems rather stable between minor versions. Only pin the major version


### PR DESCRIPTION
For more explanation, see rule 3 from:
https://blogs.gnome.org/mcatanzaro/2022/07/15/best-practices-for-build-options/

Context: https://github.com/conda-forge/pyvips-feedstock/issues/31.

Depends on: #132.